### PR TITLE
Patch: iquhack mobile

### DIFF
--- a/iquhack/static/iquhack/assets/css/custom.css
+++ b/iquhack/static/iquhack/assets/css/custom.css
@@ -103,15 +103,18 @@ img.background{
 }
 @media screen and (max-width:701px) {
     .iquhack .logo * {
-    font-size: 2rem;
+        font-size: 2rem;
+    }
+    #banner {
+        max-width: 80%;
     }
 }
 @media print  
 {
     div, li{
-    page-break-inside: avoid;
+        page-break-inside: avoid;
     }
     section{
-    page-break-after: avoid;
+        page-break-after: avoid;
     }
 }

--- a/iquhack/templates/iquhack/iquhack.html
+++ b/iquhack/templates/iquhack/iquhack.html
@@ -52,10 +52,10 @@
             <h1>{{ hackathon.start_date| date:'Y' }}</h1></div>
         <p><strong><i>{{ formatted_event_date }}</i></strong></p>
         {% if hackathon.early %}
-            <p><span>Registration Opens on</span>&nbsp;<span>{{ hackathon.opens | date:'l, F jS (P e)' }}</span></p>
+            <p><span>Registration Opens on&nbsp;</span><span>{{ hackathon.opens | date:'l, F jS' }}&nbsp;</span><span>{{ hackathon.opens | date:'(P e)' }}</span></p>
             {% if hackathon.early_note %}<p>{{ hackathon.early_note }}</p>{% endif %}
         {% elif hackathon.open %}
-            <p><span><strong>Click to Register</strong> by</span>&nbsp;<span>{{ hackathon.deadline | date:'l, F jS (P e)' }}</span></p>
+            <p><span><strong>Click to Register</strong> by&nbsp;</span><span>{{ hackathon.opens | date:'l, F jS' }}&nbsp;</span><span>{{ hackathon.opens | date:'(P e)' }}</span></p>
             {% if hackathon.open_note %}<p>{{ hackathon.open_note }}</p>{% endif %}
         {% else %}
             <p>Registration Closed</p>

--- a/iquhack/templates/iquhack/iquhack.html
+++ b/iquhack/templates/iquhack/iquhack.html
@@ -55,7 +55,7 @@
             <p><span>Registration Opens on&nbsp;</span><span>{{ hackathon.opens | date:'l, F jS' }}&nbsp;</span><span>{{ hackathon.opens | date:'(P e)' }}</span></p>
             {% if hackathon.early_note %}<p>{{ hackathon.early_note }}</p>{% endif %}
         {% elif hackathon.open %}
-            <p><span><strong>Click to Register</strong> by&nbsp;</span><span>{{ hackathon.opens | date:'l, F jS' }}&nbsp;</span><span>{{ hackathon.opens | date:'(P e)' }}</span></p>
+            <p><span><strong>Click to Register</strong> by&nbsp;</span><span>{{ hackathon.deadline | date:'l, F jS' }}&nbsp;</span><span>{{ hackathon.deadline | date:'(P e)' }}</span></p>
             {% if hackathon.open_note %}<p>{{ hackathon.open_note }}</p>{% endif %}
         {% else %}
             <p>Registration Closed</p>


### PR DESCRIPTION
Fix date wrapping and widen banner on small screens

I don't have a quick fix to nicely wrap iquhack logo and year line, but I did widen the banner area a bit for small screens.